### PR TITLE
fix: consistent body text size (first paragraph no longer oversized)

### DIFF
--- a/.changeset/paragraph-size.md
+++ b/.changeset/paragraph-size.md
@@ -1,0 +1,5 @@
+---
+"docs-diary": patch
+---
+
+fix: the first paragraph of a doc page no longer renders larger than the rest of the body. The blog-style "lede" sizing enlarged every page's opening paragraph, which made it inconsistent on docs pages (where the first paragraph is just content, not a subtitle).

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -172,12 +172,9 @@ div.markdown h6 {
   line-height: 1.7;
 }
 
-/* Lede — first paragraph after the title */
-div.markdown > h1 + p,
-div.markdown > header + p {
-  font-size: 1.1875rem;
-  margin-bottom: 32px;
-}
+/* First paragraph after the title keeps the normal body size — docs pages have
+   no designed subtitle/lede (unlike the blog), so enlarging it just makes the
+   opening line look inconsistent with the rest of the page. */
 
 /* -------------------------------------------------------------------------
    Blog-parity reading layout — narrow centered column, airy spacing, quiet


### PR DESCRIPTION
## Summary

The first paragraph of each doc page rendered larger (19px) than the rest of the body (15px), so opening lines looked inconsistent — e.g. `networking/firewall/pfsense/pfsense-password-reset` ("If the console is password protected…").

**Cause:** a blog-style "lede" rule enlarged the first paragraph after the title, assuming it's an intro/subtitle. Docs pages have no designed subtitle — the first paragraph is just content — so this only made the opening line inconsistent. Removed the rule.

**Full scan:** reviewed every `font-size` rule in the stylesheet and verified across multiple pages (pfsense, generate-csr, a table page, a blockquote page) that paragraphs, list items, admonition bodies, tab-panel content, table cells, and blockquotes all render at the consistent 15px body size (inline/block code stays at the intentional 95%). The lede was the only systemic size inconsistency.

Scope: CSS only (`src/css/custom.css`).

## Test plan

- [ ] Any doc page: the first paragraph matches the rest of the body text
- [ ] Admonitions, tabs, tables, blockquotes, and lists are all the same body size
