### PR TITLE
feat: rough-notation callouts, better code blocks, tables, and fluid titles

### DIFF
--- a/.changeset/rough-callouts-codeblocks.md
+++ b/.changeset/rough-callouts-codeblocks.md
@@ -1,0 +1,10 @@
+---
+"docs-diary": minor
+---
+
+feat: hand-drawn (rough-notation) callouts, better code blocks, cleaner tables, and fluid titles
+
+- Docusaurus admonitions (`:::note` / `:::tip` / `:::info` / `:::warning` / `:::danger`) now render as hand-drawn rough-notation callouts, with a `<Callout>` component also available in MDX.
+- Code blocks: syntax highlighting enabled for the languages the docs use (bash, sql, yaml, …) with unlabelled fences defaulting to bash; switched the dark theme off dracula to a neutral palette; bordered blocks on a neutral surface with a language badge, readable line numbers, and a readable XML prolog in dark mode.
+- Tables restyled to clean, blog-style ruled rows.
+- Page titles are now fluid (`clamp()`), scaling smoothly from phone to desktop instead of a hard breakpoint.

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -10,7 +10,7 @@ const isDeployPreview =
 const themes = require('prism-react-renderer').themes;
 
 const lightCodeTheme = themes.github;
-const darkCodeTheme = themes.dracula;
+const darkCodeTheme = themes.vsDark;
 
 const config: Config = {
   title: `Dipak's Docs Diary`,
@@ -126,6 +126,25 @@ const config: Config = {
     prism: {
       theme: lightCodeTheme,
       darkTheme: darkCodeTheme,
+      // Prism only bundles a few languages; enable the ones the docs use so
+      // bash/sql/etc. actually highlight (they were rendering monochrome).
+      additionalLanguages: [
+        'bash',
+        'shell-session',
+        'sql',
+        'php',
+        'yaml',
+        'json',
+        'ini',
+        'toml',
+        'nginx',
+        'docker',
+        'diff',
+        'powershell',
+      ],
+      // Most unlabelled code fences (```) in the docs are shell commands, so
+      // default them to bash instead of leaving them unhighlighted.
+      defaultLanguage: 'bash',
     },
     footer: {
       // style: 'light',

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react-dom": "18.3.1",
     "react-gist": "1.2.4",
     "reading-time": "1.5.0",
+    "roughjs": "^4.6.6",
     "tailwindcss": "4.1.13"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       reading-time:
         specifier: 1.5.0
         version: 1.5.0
+      roughjs:
+        specifier: ^4.6.6
+        version: 4.6.6
       tailwindcss:
         specifier: 4.1.13
         version: 4.1.13

--- a/src/components/Callout/index.tsx
+++ b/src/components/Callout/index.tsx
@@ -1,0 +1,150 @@
+import React, { useEffect, useRef } from 'react';
+import type { ReactNode } from 'react';
+import { annotate } from '@site/src/lib/vendor/rough-notation';
+import type { RoughAnnotation } from '@site/src/lib/vendor/rough-notation';
+
+// Hand-drawn (rough-notation) callout — ported from dipak.tech. Draws a sketchy
+// box around the block and reveals it on scroll. Deliberately dependency-light:
+// inline SVG icons + IntersectionObserver instead of lucide-react + framer-motion.
+
+export type CalloutType =
+  | 'note'
+  | 'info'
+  | 'tip'
+  | 'important'
+  | 'warning'
+  | 'danger'
+  | 'caution';
+
+const LABELS: Record<CalloutType, string> = {
+  note: 'Note',
+  info: 'Info',
+  tip: 'Tip',
+  important: 'Important',
+  warning: 'Warning',
+  danger: 'Danger',
+  caution: 'Caution',
+};
+
+const svg = (paths: ReactNode) => (
+  <svg
+    width="15"
+    height="15"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    {paths}
+  </svg>
+);
+
+const ICONS: Record<CalloutType, ReactNode> = {
+  note: svg(
+    <>
+      <circle cx="12" cy="12" r="10" />
+      <path d="M12 16v-4M12 8h.01" />
+    </>,
+  ),
+  info: svg(
+    <>
+      <circle cx="12" cy="12" r="10" />
+      <path d="M12 16v-4M12 8h.01" />
+    </>,
+  ),
+  tip: svg(
+    <>
+      <path d="M9 18h6M10 22h4" />
+      <path d="M12 2a7 7 0 0 0-4 12.7c.6.5 1 1.3 1 2.1V18h6v-1.2c0-.8.4-1.6 1-2.1A7 7 0 0 0 12 2Z" />
+    </>,
+  ),
+  important: svg(
+    <path d="M12 3l1.9 4.3L18 9l-4.1 1.7L12 15l-1.9-4.3L6 9l4.1-1.7L12 3ZM19 15l.8 1.8 1.8.8-1.8.8-.8 1.8-.8-1.8-1.8-.8 1.8-.8.8-1.8Z" />,
+  ),
+  warning: svg(
+    <>
+      <path d="M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0Z" />
+      <path d="M12 9v4M12 17h.01" />
+    </>,
+  ),
+  danger: svg(
+    <>
+      <path d="M7.9 2h8.2L22 7.9v8.2L16.1 22H7.9L2 16.1V7.9L7.9 2Z" />
+      <path d="M12 8v4M12 16h.01" />
+    </>,
+  ),
+  caution: svg(
+    <>
+      <path d="M7.9 2h8.2L22 7.9v8.2L16.1 22H7.9L2 16.1V7.9L7.9 2Z" />
+      <path d="M12 8v4M12 16h.01" />
+    </>,
+  ),
+};
+
+export default function Callout({
+  type = 'note',
+  title,
+  children,
+}: {
+  type?: CalloutType;
+  title?: string;
+  children: ReactNode;
+}): React.JSX.Element {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const anchorRef = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    const anchor = anchorRef.current;
+    const root = rootRef.current;
+    if (!anchor || !root) return;
+
+    const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    let annotation: RoughAnnotation | null = annotate(anchor, {
+      type: 'box',
+      strokeWidth: 1.5,
+      color: 'currentColor',
+      animationDuration: reduced ? 0 : 500,
+      animate: !reduced,
+      padding: 0,
+      iterations: 1,
+    });
+
+    let shown = false;
+    const reveal = () => {
+      if (shown || !annotation) return;
+      shown = true;
+      window.setTimeout(() => annotation?.show(), reduced ? 0 : 180);
+    };
+
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting)) {
+          reveal();
+          io.disconnect();
+        }
+      },
+      { rootMargin: '0px 0px -8% 0px' },
+    );
+    io.observe(root);
+
+    return () => {
+      io.disconnect();
+      annotation?.remove();
+      annotation = null;
+    };
+  }, []);
+
+  return (
+    <div ref={rootRef} className="mdx-callout" data-type={type} role="note">
+      <span ref={anchorRef} className="mdx-callout__rough-anchor" aria-hidden="true" />
+      <div className="mdx-callout__header">
+        {ICONS[type]}
+        <span>{title ?? LABELS[type]}</span>
+      </div>
+      <div className="mdx-callout__body">{children}</div>
+    </div>
+  );
+}

--- a/src/components/Callout/index.tsx
+++ b/src/components/Callout/index.tsx
@@ -90,7 +90,7 @@ export default function Callout({
   children,
 }: {
   type?: CalloutType;
-  title?: string;
+  title?: ReactNode;
   children: ReactNode;
 }): React.JSX.Element {
   const rootRef = useRef<HTMLDivElement>(null);

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1015,6 +1015,12 @@ a[rel='tag'] > span {
 .theme-code-block.language-mermaid::before { content: 'Mermaid'; }
 .theme-code-block.language-text::before,
 .theme-code-block.language-none::before { content: 'Text'; }
+/* When a fence sets title="…", suppress the language badge entirely so it
+   doesn't leak on top of the title header (the language-specific ::before rules
+   above aren't guarded like the generic one). */
+.theme-code-block:has([class*='codeBlockTitle'])::before {
+  content: none !important;
+}
 
 /* Explicit title header — match the language-header styling */
 [class*='codeBlockTitle'] {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -83,11 +83,17 @@
 
   --ifm-alert-padding-horizontal: 25px;
   --ifm-alert-padding-vertical: 14px;
+
+  /* Code-block surfaces (neutral, distinct from the page) */
+  --code-bg: #f6f7f9;
+  --code-header-bg: #eceef1;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
 [data-theme='dark'] {
   --ifm-color-primary: oklch(0.77 0.16 70);
+  --code-bg: #141414;
+  --code-header-bg: #1c1c1c;
   --ifm-color-primary-dark: oklch(0.71 0.16 62);
   --ifm-color-primary-darker: oklch(0.67 0.16 58);
   --ifm-color-primary-darkest: oklch(0.6 0.15 52);
@@ -945,15 +951,8 @@ a[rel='tag'] > span {
 /* -------------------------------------------------------------------------
    Code blocks — bordered wrapper on a neutral surface with a small language
    header, matching the site palette (Prism theme keeps the token colours).
+   (--code-bg / --code-header-bg are defined in the :root / dark blocks above.)
    ------------------------------------------------------------------------- */
-:root {
-  --code-bg: #f6f7f9;
-  --code-header-bg: #eceef1;
-}
-[data-theme='dark'] {
-  --code-bg: #141414;
-  --code-header-bg: #1c1c1c;
-}
 
 .theme-code-block {
   border: 1px solid var(--ifm-toc-border-color);

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -132,7 +132,9 @@
 div.markdown > h1,
 div.markdown > header > h1,
 [class*='generatedIndexPage'] h1 {
-  font-size: 2.5rem;
+  /* Fluid: scales smoothly from ~28px on phones to 40px on desktop (reaches
+     the 2.5rem cap around ~1000px) instead of a hard breakpoint jump. */
+  font-size: clamp(1.75rem, 1.3rem + 2vw, 2.5rem);
   font-weight: 500;
   letter-spacing: -0.035em;
   line-height: 1.1;
@@ -528,7 +530,7 @@ html {
 /* Tags page title — match the article/category title */
 .docs-tags-list-page h1,
 .docs-tags-doc-list-page h1 {
-  font-size: 2.5rem;
+  font-size: clamp(1.75rem, 1.3rem + 2vw, 2.5rem);
   font-weight: 500;
   letter-spacing: -0.035em;
   line-height: 1.1;
@@ -655,12 +657,7 @@ a[rel='tag'] > span {
 
 /* Mobile view */
 @media screen and (max-width: 996px) {
-  /* Smaller title on narrow screens (selector matches the header-wrapped h1) */
-  div.markdown > h1,
-  div.markdown > header > h1,
-  [class*='generatedIndexPage'] h1 {
-    font-size: 1.75rem;
-  }
+  /* (Title size is now fluid via clamp() — no breakpoint override needed.) */
 
   /* Hide the "On this page" TOC dropdown on mobile (matches the blog) */
   .theme-doc-toc-mobile {
@@ -881,4 +878,209 @@ a[rel='tag'] > span {
   display: block;
   margin: 0 calc(-1 * var(--ifm-pre-padding));
   padding: 0 var(--ifm-pre-padding);
+}
+
+/* -------------------------------------------------------------------------
+   Rough-notation callouts — Docusaurus admonitions (:::note/:::tip/:::info/
+   :::warning/:::danger) render as hand-drawn boxes (see src/theme/Admonition).
+   Ported from dipak.tech; dark mode flattened to [data-theme='dark'].
+   ------------------------------------------------------------------------- */
+.mdx-callout {
+  --co-color: oklch(50% 0.18 250);
+  --co-bg: oklch(50% 0.18 250 / 0.07);
+  position: relative;
+  color: var(--co-color); /* currentColor → rough-notation SVG stroke */
+  background: var(--co-bg);
+  border-radius: 0.35rem;
+  padding: 0.875rem 1.125rem;
+  margin: 1.5rem 0;
+}
+.mdx-callout__rough-anchor {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+.mdx-callout > svg.rough-annotation {
+  pointer-events: none;
+}
+
+/* Variant colours (light) */
+.mdx-callout[data-type='note'] { --co-color: oklch(50% 0.18 250); --co-bg: oklch(50% 0.18 250 / 0.07); }
+.mdx-callout[data-type='info'] { --co-color: oklch(54% 0.13 230); --co-bg: oklch(54% 0.13 230 / 0.07); }
+.mdx-callout[data-type='tip'] { --co-color: oklch(48% 0.17 155); --co-bg: oklch(48% 0.17 155 / 0.07); }
+.mdx-callout[data-type='important'] { --co-color: oklch(50% 0.22 300); --co-bg: oklch(50% 0.22 300 / 0.07); }
+.mdx-callout[data-type='warning'] { --co-color: oklch(58% 0.16 75); --co-bg: oklch(58% 0.16 75 / 0.07); }
+.mdx-callout[data-type='danger'],
+.mdx-callout[data-type='caution'] { --co-color: oklch(50% 0.22 25); --co-bg: oklch(50% 0.22 25 / 0.07); }
+
+/* Variant colours (dark) */
+[data-theme='dark'] .mdx-callout[data-type='note'] { --co-color: oklch(68% 0.18 250); --co-bg: oklch(68% 0.18 250 / 0.09); }
+[data-theme='dark'] .mdx-callout[data-type='info'] { --co-color: oklch(72% 0.13 230); --co-bg: oklch(72% 0.13 230 / 0.09); }
+[data-theme='dark'] .mdx-callout[data-type='tip'] { --co-color: oklch(65% 0.17 155); --co-bg: oklch(65% 0.17 155 / 0.09); }
+[data-theme='dark'] .mdx-callout[data-type='important'] { --co-color: oklch(68% 0.22 300); --co-bg: oklch(68% 0.22 300 / 0.09); }
+[data-theme='dark'] .mdx-callout[data-type='warning'] { --co-color: oklch(74% 0.16 75); --co-bg: oklch(74% 0.16 75 / 0.09); }
+[data-theme='dark'] .mdx-callout[data-type='danger'],
+[data-theme='dark'] .mdx-callout[data-type='caution'] { --co-color: oklch(68% 0.22 25); --co-bg: oklch(68% 0.22 25 / 0.09); }
+
+.mdx-callout__header {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-bottom: 0.4rem;
+  color: var(--co-color);
+  font-weight: 600;
+  font-size: 0.8rem;
+  letter-spacing: 0.01em;
+}
+.mdx-callout__body {
+  position: relative;
+  z-index: 1;
+  color: var(--ifm-font-color-base);
+}
+.mdx-callout__body > :first-child { margin-top: 0; }
+.mdx-callout__body > :last-child { margin-bottom: 0; }
+
+/* -------------------------------------------------------------------------
+   Code blocks — bordered wrapper on a neutral surface with a small language
+   header, matching the site palette (Prism theme keeps the token colours).
+   ------------------------------------------------------------------------- */
+:root {
+  --code-bg: #f6f7f9;
+  --code-header-bg: #eceef1;
+}
+[data-theme='dark'] {
+  --code-bg: #141414;
+  --code-header-bg: #1c1c1c;
+}
+
+.theme-code-block {
+  border: 1px solid var(--ifm-toc-border-color);
+  border-radius: 0.5rem;
+  overflow: hidden;
+  box-shadow: none !important;
+  /* !important so the Prism theme's own container background (e.g. dracula's
+     #282a36) can't leak around the <pre> */
+  background: var(--code-bg) !important;
+}
+.theme-code-block pre {
+  background: var(--code-bg) !important;
+  border-radius: 0;
+  padding: 0.9rem 1rem;
+  font-size: 0.82rem;
+}
+
+/* Language header — shown when the fence has no explicit title="…" */
+.theme-code-block:not(:has([class*='codeBlockTitle']))::before {
+  content: 'Code';
+  display: block;
+  padding: 0.4rem 0.9rem;
+  font-size: 0.62rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  line-height: 1;
+  color: var(--ifm-color-gray-500);
+  background: var(--code-header-bg);
+  border-bottom: 1px solid var(--ifm-toc-border-color);
+}
+.theme-code-block.language-bash::before { content: 'Bash'; }
+.theme-code-block.language-sh::before,
+.theme-code-block.language-shell::before,
+.theme-code-block.language-shell-session::before { content: 'Shell'; }
+.theme-code-block.language-sql::before { content: 'SQL'; }
+.theme-code-block.language-php::before { content: 'PHP'; }
+.theme-code-block.language-yaml::before { content: 'YAML'; }
+.theme-code-block.language-json::before { content: 'JSON'; }
+.theme-code-block.language-ini::before { content: 'INI'; }
+.theme-code-block.language-toml::before { content: 'TOML'; }
+.theme-code-block.language-nginx::before { content: 'Nginx'; }
+.theme-code-block.language-docker::before,
+.theme-code-block.language-dockerfile::before { content: 'Dockerfile'; }
+.theme-code-block.language-diff::before { content: 'Diff'; }
+.theme-code-block.language-powershell::before { content: 'PowerShell'; }
+.theme-code-block.language-js::before,
+.theme-code-block.language-javascript::before { content: 'JavaScript'; }
+.theme-code-block.language-ts::before,
+.theme-code-block.language-typescript::before { content: 'TypeScript'; }
+.theme-code-block.language-xml::before,
+.theme-code-block.language-markup::before,
+.theme-code-block.language-plist::before { content: 'XML'; }
+.theme-code-block.language-html::before { content: 'HTML'; }
+.theme-code-block.language-css::before { content: 'CSS'; }
+.theme-code-block.language-python::before,
+.theme-code-block.language-py::before { content: 'Python'; }
+.theme-code-block.language-go::before { content: 'Go'; }
+.theme-code-block.language-rust::before { content: 'Rust'; }
+.theme-code-block.language-mermaid::before { content: 'Mermaid'; }
+.theme-code-block.language-text::before,
+.theme-code-block.language-none::before { content: 'Text'; }
+
+/* Explicit title header — match the language-header styling */
+[class*='codeBlockTitle'] {
+  background: var(--code-header-bg) !important;
+  border-bottom: 1px solid var(--ifm-toc-border-color) !important;
+  font-size: 0.7rem;
+  color: var(--ifm-color-gray-500);
+}
+
+/* Copy button — sits quietly in the header row */
+.theme-code-block [class*='buttonGroup'] {
+  top: 0.25rem;
+  right: 0.4rem;
+}
+
+/* -------------------------------------------------------------------------
+   Tables — clean, blog-style: hairline row rules, no cell borders/stripes.
+   ------------------------------------------------------------------------- */
+.theme-doc-markdown table {
+  display: table;
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-size: 0.875rem;
+  border: 0;
+}
+.theme-doc-markdown table thead {
+  background: transparent;
+}
+.theme-doc-markdown table thead tr {
+  border-bottom: 1px solid var(--ifm-toc-border-color);
+}
+.theme-doc-markdown table th {
+  font-weight: 600;
+  text-align: left;
+  color: var(--ifm-heading-color);
+  padding: 0.55rem 0.9rem;
+  border: 0;
+  background: transparent;
+}
+.theme-doc-markdown table td {
+  padding: 0.55rem 0.9rem;
+  border: 0;
+  border-bottom: 1px solid var(--ifm-toc-border-color);
+  vertical-align: top;
+}
+/* No zebra striping — keep it quiet like the blog */
+.theme-doc-markdown table tr:nth-child(2n) {
+  background: transparent;
+}
+.theme-doc-markdown table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+/* Line-numbered code blocks: the number gutter kept the Prism theme's own
+   background (a lighter shade), showing as a vertical strip against our neutral
+   --code-bg. Match it so the surface is uniform. */
+.theme-code-block [class*='codeLineNumber'] {
+  background: var(--code-bg) !important;
+}
+
+/* vsDark colours the XML prolog/doctype near-black (#000080) — unreadable on
+   the dark surface. Recolour the markup meta tokens to a readable muted tone. */
+[data-theme='dark'] .theme-code-block .token.prolog,
+[data-theme='dark'] .theme-code-block .token.doctype,
+[data-theme='dark'] .theme-code-block .token.cdata {
+  color: #6a9955 !important;
 }

--- a/src/lib/vendor/rough-notation/LICENSE
+++ b/src/lib/vendor/rough-notation/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Preet Shihn
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/lib/vendor/rough-notation/README.md
+++ b/src/lib/vendor/rough-notation/README.md
@@ -1,0 +1,35 @@
+# rough-notation (vendored)
+
+This directory is a verbatim copy of the TypeScript source of
+[`rough-notation`](https://github.com/rough-stuff/rough-notation) **v0.5.1**, by
+[Preet Shihn](https://github.com/pshihn), licensed under the MIT License (see
+`LICENSE` in this directory).
+
+## Why vendored
+
+The upstream package is no longer maintained — no commits in years and the
+published npm package lists `roughjs` as a `devDependency`, so installing
+`rough-notation` from npm doesn't pull its real runtime dep. Vendoring the
+source keeps the library available, makes the runtime dependency explicit
+(`roughjs`, listed in this repo's `package.json`), and lets us patch or
+tree-shake it locally if needed.
+
+## What's here
+
+- `keyframes.ts`, `model.ts`, `render.ts`, `rough-notation.ts` — source from
+  `master` at the time of vendoring, with a small license-attribution header
+  added at the top of each file. One local adaptation in `render.ts`: the
+  `combineNestedSvgPaths` field was removed (no longer on roughjs's
+  `ResolvedOptions`) and `preserveVertices` + `fillShapeRoughnessGain` were
+  added (now required), all matching roughjs's own defaults.
+- `index.ts` — local barrel that re-exports the public API used by this repo.
+- `LICENSE` — the upstream MIT license, preserved verbatim.
+
+## Usage
+
+```ts
+import { annotate, type RoughAnnotation } from '@/lib/vendor/rough-notation';
+```
+
+The library depends on [`roughjs`](https://github.com/rough-stuff/rough), which
+remains a normal npm dependency.

--- a/src/lib/vendor/rough-notation/index.ts
+++ b/src/lib/vendor/rough-notation/index.ts
@@ -1,0 +1,19 @@
+// Vendored from rough-notation v0.5.1 — MIT © 2020 Preet Shihn.
+// Upstream: https://github.com/rough-stuff/rough-notation
+// See ./LICENSE.
+//
+// This barrel re-exports the public API that consumers in this repo use,
+// so callers can `import { annotate, type RoughAnnotation } from '@/lib/vendor/rough-notation'`.
+
+export { annotate, annotationGroup } from './rough-notation';
+export type {
+  RoughAnnotation,
+  RoughAnnotationGroup,
+  RoughAnnotationConfig,
+  RoughAnnotationConfigBase,
+  RoughAnnotationType,
+  BracketType,
+  RoughPadding,
+  FullPadding,
+  Rect,
+} from './model';

--- a/src/lib/vendor/rough-notation/keyframes.ts
+++ b/src/lib/vendor/rough-notation/keyframes.ts
@@ -1,0 +1,18 @@
+// Vendored from rough-notation v0.5.1 — MIT © 2020 Preet Shihn.
+// Upstream: https://github.com/rough-stuff/rough-notation
+// See ./LICENSE.
+
+declare global {
+  interface Window {
+    __rno_kf_s?: HTMLStyleElement;
+  }
+}
+
+export function ensureKeyframes() {
+  if (!window.__rno_kf_s) {
+    const style = document.createElement('style');
+    window.__rno_kf_s = style;
+    style.textContent = `@keyframes rough-notation-dash { to { stroke-dashoffset: 0; } }`;
+    document.head.appendChild(style);
+  }
+}

--- a/src/lib/vendor/rough-notation/model.ts
+++ b/src/lib/vendor/rough-notation/model.ts
@@ -26,7 +26,7 @@ export interface RoughAnnotationConfig extends RoughAnnotationConfigBase {
 
 export interface RoughAnnotationConfigBase {
   animate?: boolean; // defaults to true
-  animationDuration?: number; // defaulst to 1000ms
+  animationDuration?: number; // defaults to 800ms
   color?: string; // defaults to currentColor
   strokeWidth?: number; // default based on type
   padding?: RoughPadding; // defaults to 5px

--- a/src/lib/vendor/rough-notation/model.ts
+++ b/src/lib/vendor/rough-notation/model.ts
@@ -1,0 +1,51 @@
+// Vendored from rough-notation v0.5.1 — MIT © 2020 Preet Shihn.
+// Upstream: https://github.com/rough-stuff/rough-notation
+// See ./LICENSE.
+
+export const SVG_NS = 'http://www.w3.org/2000/svg';
+
+export const DEFAULT_ANIMATION_DURATION = 800;
+
+export interface Rect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export type RoughAnnotationType = 'underline' | 'box' | 'circle' | 'highlight' | 'strike-through' | 'crossed-off' | 'bracket';
+export type FullPadding = [number, number, number, number];
+export type RoughPadding = number | [number, number] | FullPadding;
+export type BracketType = 'left' | 'right' | 'top' | 'bottom';
+
+export interface RoughAnnotationConfig extends RoughAnnotationConfigBase {
+  type: RoughAnnotationType;
+  multiline?: boolean;
+  rtl?: boolean;
+}
+
+export interface RoughAnnotationConfigBase {
+  animate?: boolean; // defaults to true
+  animationDuration?: number; // defaulst to 1000ms
+  color?: string; // defaults to currentColor
+  strokeWidth?: number; // default based on type
+  padding?: RoughPadding; // defaults to 5px
+  iterations?: number; // defaults to 2
+  brackets?: BracketType | BracketType[]; // defaults to 'right'
+  // Local addition (not upstream rough-notation): draws the stroke in a
+  // few stop-and-go segments (like a hand lifting and repositioning a
+  // marker) instead of one smooth eased sweep. Defaults to false.
+  humanStroke?: boolean;
+}
+
+export interface RoughAnnotation extends RoughAnnotationConfigBase {
+  isShowing(): boolean;
+  show(): void;
+  hide(): void;
+  remove(): void;
+}
+
+export interface RoughAnnotationGroup {
+  show(): void;
+  hide(): void;
+}

--- a/src/lib/vendor/rough-notation/render.ts
+++ b/src/lib/vendor/rough-notation/render.ts
@@ -1,0 +1,309 @@
+// Vendored from rough-notation v0.5.1 — MIT © 2020 Preet Shihn.
+// Upstream: https://github.com/rough-stuff/rough-notation
+// See ./LICENSE.
+
+import { BracketType, FullPadding, Rect, RoughAnnotationConfig, SVG_NS } from './model';
+import { OpSet, ResolvedOptions } from 'roughjs/bin/core';
+import { ellipse, line, linearPath, rectangle } from 'roughjs/bin/renderer';
+
+import { Point } from 'roughjs/bin/geometry';
+
+type RoughOptionsType = 'highlight' | 'single' | 'double';
+
+function getOptions(type: RoughOptionsType, seed: number): ResolvedOptions {
+  return {
+    maxRandomnessOffset: 2,
+    roughness: type === 'highlight' ? 3.5 : 1.5,
+    bowing: 1,
+    stroke: '#000',
+    strokeWidth: 1.5,
+    curveTightness: 0,
+    curveFitting: 0.95,
+    curveStepCount: 9,
+    fillStyle: 'hachure',
+    fillWeight: -1,
+    hachureAngle: -41,
+    hachureGap: -1,
+    dashOffset: -1,
+    dashGap: -1,
+    zigzagOffset: -1,
+    // Local adaptation: `combineNestedSvgPaths` was removed and
+    // `preserveVertices` + `fillShapeRoughnessGain` were added to roughjs's
+    // ResolvedOptions in a release after rough-notation v0.5.1. Defaults
+    // mirror roughjs's own defaults.
+    preserveVertices: false,
+    fillShapeRoughnessGain: 1,
+    disableMultiStroke: type !== 'double',
+    disableMultiStrokeFill: false,
+    seed
+  };
+}
+
+// Local addition (not upstream rough-notation): a human dragging a marker
+// doesn't draw one continuous line - they stroke, lift, reposition, and
+// stroke again. Builds Web Animations keyframes for stroke-dashoffset with
+// two brief holds (flat plateaus) between three quick strokes, instead of a
+// single eased sweep from full length to 0. Timings jitter slightly per call
+// so repeated highlights on a page don't all stutter in lockstep.
+function strokeStutterKeyframes(length: number): Keyframe[] {
+  const jitterT = () => (Math.random() - 0.5) * 0.03;
+  const firstStrokeEnd = 0.5 + (Math.random() - 0.5) * 0.12; // ~44-56% drawn
+  const secondStrokeEnd = 0.06 + Math.random() * 0.06; // ~6-12% left to go
+  const t1 = 0.27 + jitterT();
+  const t2 = t1 + 0.07 + Math.random() * 0.03;
+  const t3 = 0.74 + jitterT();
+  const t4 = t3 + 0.05 + Math.random() * 0.03;
+  const toOffset = (frac: number) => `${Math.max(0, Math.min(length, frac * length))}`;
+
+  // Each stroke segment starts and ends at rest (coming out of/into a hold),
+  // so it eases both ways rather than snapping to full speed off a standstill.
+  return [
+    { offset: 0, strokeDashoffset: toOffset(1), easing: 'ease-in-out' },
+    { offset: t1, strokeDashoffset: toOffset(firstStrokeEnd), easing: 'linear' },
+    { offset: t2, strokeDashoffset: toOffset(firstStrokeEnd), easing: 'ease-in-out' },
+    { offset: t3, strokeDashoffset: toOffset(secondStrokeEnd), easing: 'linear' },
+    { offset: t4, strokeDashoffset: toOffset(secondStrokeEnd), easing: 'ease-in-out' },
+    { offset: 1, strokeDashoffset: toOffset(0) },
+  ];
+}
+
+function parsePadding(config: RoughAnnotationConfig): FullPadding {
+  const p = config.padding;
+  if (p || (p === 0)) {
+    if (typeof p === 'number') {
+      return [p, p, p, p];
+    } else if (Array.isArray(p)) {
+      const pa = p as number[];
+      if (pa.length) {
+        switch (pa.length) {
+          case 4:
+            return [...pa] as FullPadding;
+          case 1:
+            return [pa[0], pa[0], pa[0], pa[0]];
+          case 2:
+            return [...pa, ...pa] as FullPadding;
+          case 3:
+            return [...pa, pa[1]] as FullPadding;
+          default:
+            return [pa[0], pa[1], pa[2], pa[3]];
+        }
+      }
+    }
+  }
+  return [5, 5, 5, 5];
+}
+
+export function renderAnnotation(svg: SVGSVGElement, rect: Rect, config: RoughAnnotationConfig, animationGroupDelay: number, animationDuration: number, seed: number) {
+  const opList: OpSet[] = [];
+  let strokeWidth = config.strokeWidth || 2;
+  const padding = parsePadding(config);
+  const animate = (config.animate === undefined) ? true : (!!config.animate);
+  const iterations = config.iterations || 2;
+  const rtl = config.rtl ? 1 : 0;
+  const o = getOptions('single', seed);
+
+  switch (config.type) {
+    case 'underline': {
+      const y = rect.y + rect.h + padding[2];
+      for (let i = rtl; i < iterations + rtl; i++) {
+        if (i % 2) {
+          opList.push(line(rect.x + rect.w, y, rect.x, y, o));
+        } else {
+          opList.push(line(rect.x, y, rect.x + rect.w, y, o));
+        }
+      }
+      break;
+    }
+    case 'strike-through': {
+      const y = rect.y + (rect.h / 2);
+      for (let i = rtl; i < iterations + rtl; i++) {
+        if (i % 2) {
+          opList.push(line(rect.x + rect.w, y, rect.x, y, o));
+        } else {
+          opList.push(line(rect.x, y, rect.x + rect.w, y, o));
+        }
+      }
+      break;
+    }
+    case 'box': {
+      const x = rect.x - padding[3];
+      const y = rect.y - padding[0];
+      const width = rect.w + (padding[1] + padding[3]);
+      const height = rect.h + (padding[0] + padding[2]);
+      for (let i = 0; i < iterations; i++) {
+        opList.push(rectangle(x, y, width, height, o));
+      }
+      break;
+    }
+    case 'bracket': {
+      const brackets: BracketType[] = Array.isArray(config.brackets) ? config.brackets : (config.brackets ? [config.brackets] : ['right']);
+      const lx = rect.x - padding[3] * 2;
+      const rx = rect.x + rect.w + padding[1] * 2;
+      const ty = rect.y - padding[0] * 2;
+      const by = rect.y + rect.h + padding[2] * 2;
+      for (const br of brackets) {
+        let points: Point[];
+        switch (br) {
+          case 'bottom':
+            points = [
+              [lx, rect.y + rect.h],
+              [lx, by],
+              [rx, by],
+              [rx, rect.y + rect.h]
+            ];
+            break;
+          case 'top':
+            points = [
+              [lx, rect.y],
+              [lx, ty],
+              [rx, ty],
+              [rx, rect.y]
+            ];
+            break;
+          case 'left':
+            points = [
+              [rect.x, ty],
+              [lx, ty],
+              [lx, by],
+              [rect.x, by]
+            ];
+            break;
+          case 'right':
+            points = [
+              [rect.x + rect.w, ty],
+              [rx, ty],
+              [rx, by],
+              [rect.x + rect.w, by]
+            ];
+            break;
+        }
+        if (points) {
+          opList.push(linearPath(points, false, o));
+        }
+      }
+      break;
+    }
+    case 'crossed-off': {
+      const x = rect.x;
+      const y = rect.y;
+      const x2 = x + rect.w;
+      const y2 = y + rect.h;
+      for (let i = rtl; i < iterations + rtl; i++) {
+        if (i % 2) {
+          opList.push(line(x2, y2, x, y, o));
+        } else {
+          opList.push(line(x, y, x2, y2, o));
+        }
+      }
+      for (let i = rtl; i < iterations + rtl; i++) {
+        if (i % 2) {
+          opList.push(line(x, y2, x2, y, o));
+        } else {
+          opList.push(line(x2, y, x, y2, o));
+        }
+      }
+      break;
+    }
+    case 'circle': {
+      const doubleO = getOptions('double', seed);
+      const width = rect.w + (padding[1] + padding[3]);
+      const height = rect.h + (padding[0] + padding[2]);
+      const x = rect.x - padding[3] + (width / 2);
+      const y = rect.y - padding[0] + (height / 2);
+      const fullItr = Math.floor(iterations / 2);
+      const singleItr = iterations - (fullItr * 2);
+      for (let i = 0; i < fullItr; i++) {
+        opList.push(ellipse(x, y, width, height, doubleO));
+      }
+      for (let i = 0; i < singleItr; i++) {
+        opList.push(ellipse(x, y, width, height, o));
+      }
+      break;
+    }
+    case 'highlight': {
+      const o = getOptions('highlight', seed);
+      strokeWidth = rect.h * 0.95;
+      const y = rect.y + (rect.h / 2);
+      for (let i = rtl; i < iterations + rtl; i++) {
+        if (i % 2) {
+          opList.push(line(rect.x + rect.w, y, rect.x, y, o));
+        } else {
+          opList.push(line(rect.x, y, rect.x + rect.w, y, o));
+        }
+      }
+      break;
+    }
+  }
+
+  if (opList.length) {
+    const pathStrings = opsToPath(opList);
+    const lengths: number[] = [];
+    const pathElements: SVGPathElement[] = [];
+    let totalLength = 0;
+    const setAttr = (p: SVGPathElement, an: string, av: string) => p.setAttribute(an, av);
+
+    for (const d of pathStrings) {
+      const path = document.createElementNS(SVG_NS, 'path');
+      setAttr(path, 'd', d);
+      setAttr(path, 'fill', 'none');
+      setAttr(path, 'stroke', config.color || 'currentColor');
+      setAttr(path, 'stroke-width', `${strokeWidth}`);
+      if (animate) {
+        const length = path.getTotalLength();
+        lengths.push(length);
+        totalLength += length;
+      }
+      svg.appendChild(path);
+      pathElements.push(path);
+    }
+
+    if (animate) {
+      let durationOffset = 0;
+      for (let i = 0; i < pathElements.length; i++) {
+        const path = pathElements[i];
+        const length = lengths[i];
+        const duration = totalLength ? (animationDuration * (length / totalLength)) : 0;
+        const delay = animationGroupDelay + durationOffset;
+        const style = path.style;
+        style.strokeDashoffset = `${length}`;
+        style.strokeDasharray = `${length}`;
+        if (duration <= 0) {
+          style.strokeDashoffset = '0';
+        } else if (config.humanStroke) {
+          path.animate(strokeStutterKeyframes(length), { duration, delay, fill: 'forwards' });
+        } else {
+          style.animation = `rough-notation-dash ${duration}ms cubic-bezier(0.22, 0.61, 0.36, 1) ${delay}ms forwards`;
+        }
+        durationOffset += duration;
+      }
+    }
+  }
+}
+
+function opsToPath(opList: OpSet[]): string[] {
+  const paths: string[] = [];
+  for (const drawing of opList) {
+    let path = '';
+    for (const item of drawing.ops) {
+      const data = item.data;
+      switch (item.op) {
+        case 'move':
+          if (path.trim()) {
+            paths.push(path.trim());
+          }
+          path = `M${data[0]} ${data[1]} `;
+          break;
+        case 'bcurveTo':
+          path += `C${data[0]} ${data[1]}, ${data[2]} ${data[3]}, ${data[4]} ${data[5]} `;
+          break;
+        case 'lineTo':
+          path += `L${data[0]} ${data[1]} `;
+          break;
+      }
+    }
+    if (path.trim()) {
+      paths.push(path.trim());
+    }
+  }
+  return paths;
+}

--- a/src/lib/vendor/rough-notation/rough-notation.ts
+++ b/src/lib/vendor/rough-notation/rough-notation.ts
@@ -1,0 +1,283 @@
+// Vendored from rough-notation v0.5.1 — MIT © 2020 Preet Shihn.
+// Upstream: https://github.com/rough-stuff/rough-notation
+// See ./LICENSE.
+
+import { Rect, RoughAnnotationConfig, RoughAnnotation, SVG_NS, RoughAnnotationGroup, DEFAULT_ANIMATION_DURATION } from './model';
+import { renderAnnotation } from './render';
+import { ensureKeyframes } from './keyframes';
+import { randomSeed } from 'roughjs/bin/math';
+
+type AnnotationState = 'unattached' | 'not-showing' | 'showing';
+
+class RoughAnnotationImpl implements RoughAnnotation {
+  private _state: AnnotationState = 'unattached';
+  private _config: RoughAnnotationConfig;
+  private _resizing = false;
+  private _ro?: ResizeObserver;
+  private _seed = randomSeed();
+
+  private _e: HTMLElement;
+  private _svg?: SVGSVGElement;
+  private _lastSizes: Rect[] = [];
+
+  _animationDelay = 0;
+
+  constructor(e: HTMLElement, config: RoughAnnotationConfig) {
+    this._e = e;
+    this._config = JSON.parse(JSON.stringify(config));
+    this.attach();
+  }
+
+  get animate() { return this._config.animate; }
+  set animate(value) { this._config.animate = value; }
+
+  get animationDuration() { return this._config.animationDuration; }
+  set animationDuration(value) { this._config.animationDuration = value; }
+
+  get iterations() { return this._config.iterations; }
+  set iterations(value) { this._config.iterations = value; }
+
+  get color() { return this._config.color; }
+  set color(value) {
+    if (this._config.color !== value) {
+      this._config.color = value;
+      this.refresh();
+    }
+  }
+
+  get strokeWidth() { return this._config.strokeWidth; }
+  set strokeWidth(value) {
+    if (this._config.strokeWidth !== value) {
+      this._config.strokeWidth = value;
+      this.refresh();
+    }
+  }
+
+  get padding() { return this._config.padding; }
+  set padding(value) {
+    if (this._config.padding !== value) {
+      this._config.padding = value;
+      this.refresh();
+    }
+  }
+
+  private _resizeListener = () => {
+    if (!this._resizing) {
+      this._resizing = true;
+      setTimeout(() => {
+        this._resizing = false;
+        if (this._state === 'showing') {
+          if (this.haveRectsChanged()) {
+            this.show();
+          }
+        }
+      }, 400);
+    }
+  }
+
+  private attach() {
+    if (this._state === 'unattached' && this._e.parentElement) {
+      ensureKeyframes();
+      const svg = this._svg = document.createElementNS(SVG_NS, 'svg');
+      svg.setAttribute('class', 'rough-annotation');
+      const style = svg.style;
+      style.position = 'absolute';
+      style.top = '0';
+      style.left = '0';
+      style.overflow = 'visible';
+      style.pointerEvents = 'none';
+      style.width = '100px';
+      style.height = '100px';
+      const prepend = this._config.type === 'highlight';
+      this._e.insertAdjacentElement(prepend ? 'beforebegin' : 'afterend', svg);
+      this._state = 'not-showing';
+
+      // ensure e is positioned
+      if (prepend) {
+        const computedPos = window.getComputedStyle(this._e).position;
+        const unpositioned = (!computedPos) || (computedPos === 'static');
+        if (unpositioned) {
+          this._e.style.position = 'relative';
+        }
+      }
+      this.attachListeners();
+    }
+  }
+
+  private detachListeners() {
+    window.removeEventListener('resize', this._resizeListener);
+    if (this._ro) {
+      this._ro.unobserve(this._e);
+    }
+  }
+
+  private attachListeners() {
+    this.detachListeners();
+    window.addEventListener('resize', this._resizeListener, { passive: true });
+    if ((!this._ro) && ('ResizeObserver' in window)) {
+      this._ro = new ResizeObserver((entries: ResizeObserverEntry[]) => {
+        for (const entry of entries) {
+          if (entry.contentRect) {
+            this._resizeListener();
+          }
+        }
+      });
+    }
+    if (this._ro) {
+      this._ro.observe(this._e);
+    }
+  }
+
+  private haveRectsChanged(): boolean {
+    if (this._lastSizes.length) {
+      const newRects = this.rects();
+      if (newRects.length === this._lastSizes.length) {
+        for (let i = 0; i < newRects.length; i++) {
+          if (!this.isSameRect(newRects[i], this._lastSizes[i])) {
+            return true;
+          }
+        }
+      } else {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private isSameRect(rect1: Rect, rect2: Rect): boolean {
+    const si = (a: number, b: number) => Math.round(a) === Math.round(b);
+    return (
+      si(rect1.x, rect2.x) &&
+      si(rect1.y, rect2.y) &&
+      si(rect1.w, rect2.w) &&
+      si(rect1.h, rect2.h)
+    );
+  }
+
+  isShowing(): boolean {
+    return (this._state !== 'not-showing');
+  }
+
+  private pendingRefresh?: Promise<void>;
+  private refresh() {
+    if (this.isShowing() && (!this.pendingRefresh)) {
+      this.pendingRefresh = Promise.resolve().then(() => {
+        if (this.isShowing()) {
+          this.show();
+        }
+        delete this.pendingRefresh;
+      });
+    }
+  }
+
+  show(): void {
+    switch (this._state) {
+      case 'unattached':
+        break;
+      case 'showing':
+        this.hide();
+        if (this._svg) {
+          this.render(this._svg, true);
+        }
+        break;
+      case 'not-showing':
+        this.attach();
+        if (this._svg) {
+          this.render(this._svg, false);
+        }
+        break;
+    }
+  }
+
+  hide(): void {
+    if (this._svg) {
+      while (this._svg.lastChild) {
+        this._svg.removeChild(this._svg.lastChild);
+      }
+    }
+    this._state = 'not-showing';
+  }
+
+  remove(): void {
+    if (this._svg && this._svg.parentElement) {
+      this._svg.parentElement.removeChild(this._svg);
+    }
+    this._svg = undefined;
+    this._state = 'unattached';
+    this.detachListeners();
+  }
+
+  private render(svg: SVGSVGElement, ensureNoAnimation: boolean) {
+    let config = this._config;
+    if (ensureNoAnimation) {
+      config = JSON.parse(JSON.stringify(this._config));
+      config.animate = false;
+    }
+    const rects = this.rects();
+    let totalWidth = 0;
+    rects.forEach((rect) => totalWidth += rect.w);
+    const totalDuration = (config.animationDuration || DEFAULT_ANIMATION_DURATION);
+    let delay = 0;
+    for (let i = 0; i < rects.length; i++) {
+      const rect = rects[i];
+      const ad = totalDuration * (rect.w / totalWidth);
+      renderAnnotation(svg, rects[i], config, delay + this._animationDelay, ad, this._seed);
+      delay += ad;
+    }
+    this._lastSizes = rects;
+    this._state = 'showing';
+  }
+
+  private rects(): Rect[] {
+    const ret: Rect[] = [];
+    if (this._svg) {
+      if (this._config.multiline) {
+        const elementRects = this._e.getClientRects();
+        for (let i = 0; i < elementRects.length; i++) {
+          ret.push(this.svgRect(this._svg, elementRects[i]));
+        }
+      } else {
+        ret.push(this.svgRect(this._svg, this._e.getBoundingClientRect()));
+      }
+    }
+    return ret;
+  }
+
+  private svgRect(svg: SVGSVGElement, bounds: DOMRect | DOMRectReadOnly): Rect {
+    const rect1 = svg.getBoundingClientRect();
+    const rect2 = bounds;
+    return {
+      x: (rect2.x || rect2.left) - (rect1.x || rect1.left),
+      y: (rect2.y || rect2.top) - (rect1.y || rect1.top),
+      w: rect2.width,
+      h: rect2.height
+    };
+  }
+}
+
+export function annotate(element: HTMLElement, config: RoughAnnotationConfig): RoughAnnotation {
+  return new RoughAnnotationImpl(element, config);
+}
+
+export function annotationGroup(annotations: RoughAnnotation[]): RoughAnnotationGroup {
+  let delay = 0;
+  for (const a of annotations) {
+    const ai = a as RoughAnnotationImpl;
+    ai._animationDelay = delay;
+    const duration = ai.animationDuration === 0 ? 0 : (ai.animationDuration || DEFAULT_ANIMATION_DURATION);
+    delay += duration;
+  }
+  const list = [...annotations];
+  return {
+    show() {
+      for (const a of list) {
+        a.show();
+      }
+    },
+    hide() {
+      for (const a of list) {
+        a.hide();
+      }
+    }
+  };
+}

--- a/src/theme/Admonition/index.tsx
+++ b/src/theme/Admonition/index.tsx
@@ -20,12 +20,10 @@ const TYPE_MAP: Record<string, CalloutType> = {
 
 export default function Admonition(props: Props): React.JSX.Element {
   const type = TYPE_MAP[props.type ?? 'note'] ?? 'note';
-  // Docusaurus passes `title` as a node when the author wrote `:::tip[Title]`;
-  // fall back to the Callout's default label otherwise.
-  const title =
-    typeof props.title === 'string' ? props.title : undefined;
+  // Pass `title` straight through — it may be a ReactNode (e.g. `:::tip[**Bold**]`);
+  // Callout falls back to its default label when it's undefined.
   return (
-    <Callout type={type} title={title}>
+    <Callout type={type} title={props.title}>
       {props.children}
     </Callout>
   );

--- a/src/theme/Admonition/index.tsx
+++ b/src/theme/Admonition/index.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import type { Props } from '@theme/Admonition';
+import Callout from '@site/src/components/Callout';
+import type { CalloutType } from '@site/src/components/Callout';
+
+// Render Docusaurus admonitions (:::note, :::tip, :::info, :::warning, :::danger)
+// as hand-drawn rough-notation callouts, so existing docs get the look for free.
+
+const TYPE_MAP: Record<string, CalloutType> = {
+  note: 'note',
+  info: 'info',
+  tip: 'tip',
+  important: 'important',
+  success: 'tip',
+  secondary: 'note',
+  warning: 'warning',
+  caution: 'caution',
+  danger: 'danger',
+};
+
+export default function Admonition(props: Props): React.JSX.Element {
+  const type = TYPE_MAP[props.type ?? 'note'] ?? 'note';
+  // Docusaurus passes `title` as a node when the author wrote `:::tip[Title]`;
+  // fall back to the Callout's default label otherwise.
+  const title =
+    typeof props.title === 'string' ? props.title : undefined;
+  return (
+    <Callout type={type} title={title}>
+      {props.children}
+    </Callout>
+  );
+}

--- a/src/theme/MDXComponents.tsx
+++ b/src/theme/MDXComponents.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import MDXComponents from '@theme-original/MDXComponents';
+import Callout from '@site/src/components/Callout';
+
+// Make <Callout> usable directly in any .md/.mdx file (in addition to the
+// :::note/:::tip admonitions, which are mapped to it via the Admonition swizzle).
+export default {
+  ...MDXComponents,
+  Callout,
+};


### PR DESCRIPTION
## Summary

A batch of content-presentation improvements, themed to match dipak.tech.

### Rough-notation callouts
- Docusaurus admonitions (`:::note` / `:::tip` / `:::info` / `:::warning` / `:::danger`) now render as **hand-drawn rough-notation callouts** — a sketchy box drawn around the block, revealed on scroll.
- Works on existing docs with **no content changes** (via an `@theme/Admonition` swizzle). `<Callout type="tip">…</Callout>` is also registered for direct use in MDX.
- Ports the vendored `rough-notation` lib from dipak.tech; the only new dependency is `roughjs`. Kept lean — inline SVG icons + `IntersectionObserver` instead of `lucide-react` + `framer-motion`.

### Code blocks
- **Highlighting fixed**: `additionalLanguages` (bash, sql, yaml, json, …) enabled — they were rendering monochrome — and unlabelled fences now `defaultLanguage: bash`.
- Dark theme switched off **dracula** to a neutral palette (`vsDark`); the code surface is now a neutral `#141414`/`#f6f7f9` instead of dracula purple.
- Bordered blocks with a **language badge header**, quiet copy button, uniform line-number gutter (fixed a vertical strip), and a readable XML prolog in dark mode.

### Tables & titles
- Tables restyled to clean, blog-style ruled rows (bold header, hairline row rules, no cell borders/zebra).
- Page titles are now **fluid** (`clamp(1.75rem, 1.3rem + 2vw, 2.5rem)`) — smooth scaling from phone → desktop instead of a hard breakpoint.

## Test plan

- [ ] `:::note/:::tip/:::info/:::warning/:::danger` render as rough callouts (light + dark)
- [ ] Code blocks highlight (bash/sql/etc.), neutral surface, language badge, readable line numbers + XML in dark
- [ ] Tables render as clean ruled rows
- [ ] Page title scales smoothly across phone / tablet / desktop
- [ ] Production build passes (verified locally)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added hand-drawn styled callouts for notes, tips, warnings, and other admonitions.
  - Added a reusable Callout component for MDX documentation.
  - Improved code blocks with broader syntax highlighting, language labels, readable line numbers, and clearer dark-mode styling.

- **Style Improvements**
  - Refined table styling with clean ruled rows.
  - Made page titles scale smoothly across screen sizes.
  - Updated dark-theme code colors for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->