### PR TITLE
feat: llms.txt/markdown export + page AI actions

### DIFF
--- a/.changeset/llms-txt-page-actions.md
+++ b/.changeset/llms-txt-page-actions.md
@@ -1,0 +1,5 @@
+---
+"docs-diary": minor
+---
+
+feat: generate `llms.txt`, `llms-full.txt`, and a raw `*.md` copy of every doc page (in both `pnpm start` and `pnpm build`), and add an "Open" toolbar on each doc page for opening the page in GitHub, ChatGPT, or Claude.

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -164,6 +164,7 @@ const config: Config = {
 
   // Plugins are used to extend the functionality of Docusaurus.
   plugins: [
+    require.resolve('./src/plugins/llms-txt'),
     [
       require.resolve('@docusaurus/plugin-client-redirects'),
       {

--- a/src/components/PageActions/index.tsx
+++ b/src/components/PageActions/index.tsx
@@ -1,0 +1,112 @@
+import React, {useState, type ReactNode} from 'react';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import {useDoc} from '@docusaurus/plugin-content-docs/client';
+import styles from './styles.module.css';
+
+// Mirrors the root-route special-case in src/plugins/llms-txt.js.
+function markdownPath(permalink: string): string {
+  return permalink === '/' ? '/index.md' : `${permalink}.md`;
+}
+
+function CopyIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <rect x="9" y="9" width="13" height="13" rx="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <path d="M20 6 9 17l-5-5" />
+    </svg>
+  );
+}
+
+function ChevronDownIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <path d="m6 9 6 6 6-6" />
+    </svg>
+  );
+}
+
+function GitHubIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+    </svg>
+  );
+}
+
+function ChatGPTIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor">
+      <path d="M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z" />
+    </svg>
+  );
+}
+
+function ClaudeIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor">
+      <path d="M17.3041 3.541h-3.6718l6.696 16.918H24Zm-10.6082 0L0 20.459h3.7442l1.3693-3.5527h7.0052l1.3693 3.5528h3.7442L10.5363 3.5409Zm-.3712 10.2232 2.2914-5.9456 2.2914 5.9456Z" />
+    </svg>
+  );
+}
+
+export default function PageActions(): ReactNode {
+  const {siteConfig} = useDocusaurusContext();
+  const {metadata} = useDoc();
+  const [copied, setCopied] = useState(false);
+
+  const markdownUrl = `${siteConfig.url}${markdownPath(metadata.permalink)}`;
+  const githubUrl = metadata.editUrl?.replace('/edit/', '/blob/');
+  const prompt = `Read ${markdownUrl}, I want to ask questions about it.`;
+
+  const links = [
+    githubUrl && {label: 'Open in GitHub', href: githubUrl, icon: <GitHubIcon />},
+    {
+      label: 'Open in ChatGPT',
+      href: `https://chatgpt.com/?${new URLSearchParams({prompt, hints: 'search'})}`,
+      icon: <ChatGPTIcon />,
+    },
+    {
+      label: 'Open in Claude',
+      href: `https://claude.ai/new?${new URLSearchParams({q: prompt})}`,
+      icon: <ClaudeIcon />,
+    },
+  ].filter((link): link is {label: string; href: string; icon: ReactNode} => Boolean(link));
+
+  async function copyMarkdown() {
+    const text = await fetch(markdownUrl).then((res) => res.text());
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  }
+
+  return (
+    <div className={styles.actions}>
+      <button type="button" className={styles.button} onClick={copyMarkdown}>
+        {copied ? <CheckIcon /> : <CopyIcon />}
+        {copied ? 'Copied' : 'Copy Markdown'}
+      </button>
+      <details className={styles.menu}>
+        <summary className={styles.button}>
+          Open
+          <ChevronDownIcon />
+        </summary>
+        <div className={styles.dropdown}>
+          {links.map((link) => (
+            <a key={link.href} href={link.href} target="_blank" rel="noreferrer noopener">
+              {link.icon}
+              {link.label}
+            </a>
+          ))}
+        </div>
+      </details>
+    </div>
+  );
+}

--- a/src/components/PageActions/index.tsx
+++ b/src/components/PageActions/index.tsx
@@ -1,4 +1,4 @@
-import React, {useState, type ReactNode} from 'react';
+import React, {type ReactNode} from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import {useDoc} from '@docusaurus/plugin-content-docs/client';
 import styles from './styles.module.css';
@@ -6,23 +6,6 @@ import styles from './styles.module.css';
 // Mirrors the root-route special-case in src/plugins/llms-txt.js.
 function markdownPath(permalink: string): string {
   return permalink === '/' ? '/index.md' : `${permalink}.md`;
-}
-
-function CopyIcon() {
-  return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-      <rect x="9" y="9" width="13" height="13" rx="2" />
-      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-    </svg>
-  );
-}
-
-function CheckIcon() {
-  return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-      <path d="M20 6 9 17l-5-5" />
-    </svg>
-  );
 }
 
 function ChevronDownIcon() {
@@ -60,7 +43,6 @@ function ClaudeIcon() {
 export default function PageActions(): ReactNode {
   const {siteConfig} = useDocusaurusContext();
   const {metadata} = useDoc();
-  const [copied, setCopied] = useState(false);
 
   const markdownUrl = `${siteConfig.url}${markdownPath(metadata.permalink)}`;
   const githubUrl = metadata.editUrl?.replace('/edit/', '/blob/');
@@ -80,19 +62,8 @@ export default function PageActions(): ReactNode {
     },
   ].filter((link): link is {label: string; href: string; icon: ReactNode} => Boolean(link));
 
-  async function copyMarkdown() {
-    const text = await fetch(markdownUrl).then((res) => res.text());
-    await navigator.clipboard.writeText(text);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1500);
-  }
-
   return (
     <div className={styles.actions}>
-      <button type="button" className={styles.button} onClick={copyMarkdown}>
-        {copied ? <CheckIcon /> : <CopyIcon />}
-        {copied ? 'Copied' : 'Copy Markdown'}
-      </button>
       <details className={styles.menu}>
         <summary className={styles.button}>
           Open

--- a/src/components/PageActions/styles.module.css
+++ b/src/components/PageActions/styles.module.css
@@ -1,0 +1,78 @@
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  margin: 0.75rem 0 1.25rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.3rem 0.55rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--ifm-font-color-base);
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-global-radius);
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+}
+
+.button svg {
+  width: 0.875rem;
+  height: 0.875rem;
+  flex-shrink: 0;
+}
+
+.button::-webkit-details-marker {
+  display: none;
+}
+
+.button:hover {
+  border-color: color-mix(in srgb, var(--ifm-color-primary) 50%, var(--ifm-color-emphasis-300));
+  color: var(--ifm-color-primary);
+}
+
+.menu {
+  position: relative;
+}
+
+.dropdown {
+  position: absolute;
+  top: calc(100% + 0.375rem);
+  left: 0;
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  min-width: 11rem;
+  padding: 0.25rem;
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-global-radius);
+  box-shadow: var(--ifm-global-shadow-md);
+}
+
+.dropdown a {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.4rem 0.55rem;
+  font-size: 0.75rem;
+  color: var(--ifm-font-color-base);
+  text-decoration: none;
+  border-radius: calc(var(--ifm-global-radius) - 0.2rem);
+}
+
+.dropdown a svg {
+  width: 0.875rem;
+  height: 0.875rem;
+  flex-shrink: 0;
+}
+
+.dropdown a:hover {
+  color: var(--ifm-color-primary);
+  background: color-mix(in srgb, var(--ifm-color-primary) 10%, transparent);
+}

--- a/src/plugins/llms-txt.js
+++ b/src/plugins/llms-txt.js
@@ -1,0 +1,58 @@
+// ponytail: hand-rolled instead of a third-party plugin — the routes and
+// titles already come out of the content-docs plugin, so this is just a
+// postBuild read of that data plus two text files.
+const fs = require('fs');
+const path = require('path');
+
+const SITE_DIR = path.join(__dirname, '..', '..');
+
+function stripFrontMatter(raw) {
+  return raw.replace(/^---\n[\s\S]*?\n---\n?/, '');
+}
+
+// Fumadocs-style: llms.txt (index), llms-full.txt (everything), and a raw
+// *.md copy of every page for agents that fetch `<url>.md` directly.
+async function postBuild({ outDir, siteConfig, plugins }) {
+  const docsPlugins = plugins.filter((p) => p.name === 'docusaurus-plugin-content-docs');
+  const docs = docsPlugins
+    .flatMap((p) => p.content?.loadedVersions ?? [])
+    .flatMap((v) => v.docs)
+    .filter((d) => !d.draft && !d.unlisted);
+
+  const pages = docs
+    .map((doc) => {
+      const filePath = path.join(SITE_DIR, doc.source.replace(/^@site[\\/]/, ''));
+      const body = stripFrontMatter(fs.readFileSync(filePath, 'utf8')).trim();
+      return { route: doc.permalink, title: doc.title, body };
+    })
+    .sort((a, b) => a.route.localeCompare(b.route));
+
+  // ponytail: root route ("/") would otherwise write a hidden `.md` dotfile,
+  // which some static hosts refuse to serve — use index.md there instead.
+  const mdPath = (route) => (route === '/' ? '/index.md' : `${route}.md`);
+
+  for (const page of pages) {
+    const dest = path.join(outDir, mdPath(page.route));
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.writeFileSync(dest, page.body);
+  }
+
+  const index = [
+    `# ${siteConfig.title}`,
+    '',
+    `> ${siteConfig.url}`,
+    '',
+    '## Docs',
+    '',
+    ...pages.map((p) => `- [${p.title}](${siteConfig.url}${mdPath(p.route)})`),
+    '',
+  ].join('\n');
+  fs.writeFileSync(path.join(outDir, 'llms.txt'), index);
+
+  const full = pages.map((p) => `# ${p.title}\n\n${p.body}`).join('\n\n---\n\n');
+  fs.writeFileSync(path.join(outDir, 'llms-full.txt'), full);
+}
+
+module.exports = function llmsTxtPlugin() {
+  return { name: 'llms-txt', postBuild };
+};

--- a/src/plugins/llms-txt.js
+++ b/src/plugins/llms-txt.js
@@ -31,10 +31,13 @@ async function postBuild({ outDir, siteConfig, plugins }) {
   // which some static hosts refuse to serve — use index.md there instead.
   const mdPath = (route) => (route === '/' ? '/index.md' : `${route}.md`);
 
+  // So an agent reading a single page can discover the rest of the site.
+  const footer = `\n\n---\n\nFull site index: ${siteConfig.url}/llms.txt\nFull site content: ${siteConfig.url}/llms-full.txt\n`;
+
   for (const page of pages) {
     const dest = path.join(outDir, mdPath(page.route));
     fs.mkdirSync(path.dirname(dest), { recursive: true });
-    fs.writeFileSync(dest, page.body);
+    fs.writeFileSync(dest, page.body + footer);
   }
 
   const index = [

--- a/src/plugins/llms-txt.js
+++ b/src/plugins/llms-txt.js
@@ -1,46 +1,40 @@
 // ponytail: hand-rolled instead of a third-party plugin — the routes and
-// titles already come out of the content-docs plugin, so this is just a
-// postBuild read of that data plus two text files.
+// titles already come out of the content-docs plugin, so this is just
+// reading that data plus writing/serving two text files.
 const fs = require('fs');
 const path = require('path');
-
-const SITE_DIR = path.join(__dirname, '..', '..');
 
 function stripFrontMatter(raw) {
   return raw.replace(/^---\n[\s\S]*?\n---\n?/, '');
 }
 
-// Fumadocs-style: llms.txt (index), llms-full.txt (everything), and a raw
-// *.md copy of every page for agents that fetch `<url>.md` directly.
-async function postBuild({ outDir, siteConfig, plugins }) {
-  const docsPlugins = plugins.filter((p) => p.name === 'docusaurus-plugin-content-docs');
-  const docs = docsPlugins
-    .flatMap((p) => p.content?.loadedVersions ?? [])
+// ponytail: root route ("/") would otherwise write a hidden `.md` dotfile,
+// which some static hosts refuse to serve — use index.md there instead.
+function mdPath(route) {
+  return route === '/' ? '/index.md' : `${route}.md`;
+}
+
+function buildPages(allContent, siteDir) {
+  const docs = Object.values(allContent['docusaurus-plugin-content-docs'] ?? {})
+    .flatMap((content) => content?.loadedVersions ?? [])
     .flatMap((v) => v.docs)
     .filter((d) => !d.draft && !d.unlisted);
 
-  const pages = docs
+  return docs
     .map((doc) => {
-      const filePath = path.join(SITE_DIR, doc.source.replace(/^@site[\\/]/, ''));
+      const filePath = path.join(siteDir, doc.source.replace(/^@site[\\/]/, ''));
       const body = stripFrontMatter(fs.readFileSync(filePath, 'utf8')).trim();
-      return { route: doc.permalink, title: doc.title, body };
+      return {route: doc.permalink, title: doc.title, body};
     })
     .sort((a, b) => a.route.localeCompare(b.route));
+}
 
-  // ponytail: root route ("/") would otherwise write a hidden `.md` dotfile,
-  // which some static hosts refuse to serve — use index.md there instead.
-  const mdPath = (route) => (route === '/' ? '/index.md' : `${route}.md`);
+function footer(siteUrl) {
+  return `\n\n---\n\nFull site index: ${siteUrl}/llms.txt\nFull site content: ${siteUrl}/llms-full.txt\n`;
+}
 
-  // So an agent reading a single page can discover the rest of the site.
-  const footer = `\n\n---\n\nFull site index: ${siteConfig.url}/llms.txt\nFull site content: ${siteConfig.url}/llms-full.txt\n`;
-
-  for (const page of pages) {
-    const dest = path.join(outDir, mdPath(page.route));
-    fs.mkdirSync(path.dirname(dest), { recursive: true });
-    fs.writeFileSync(dest, page.body + footer);
-  }
-
-  const index = [
+function buildIndex(pages, siteConfig) {
+  return [
     `# ${siteConfig.title}`,
     '',
     `> ${siteConfig.url}`,
@@ -50,12 +44,72 @@ async function postBuild({ outDir, siteConfig, plugins }) {
     ...pages.map((p) => `- [${p.title}](${siteConfig.url}${mdPath(p.route)})`),
     '',
   ].join('\n');
-  fs.writeFileSync(path.join(outDir, 'llms.txt'), index);
-
-  const full = pages.map((p) => `# ${p.title}\n\n${p.body}`).join('\n\n---\n\n');
-  fs.writeFileSync(path.join(outDir, 'llms-full.txt'), full);
 }
 
-module.exports = function llmsTxtPlugin() {
-  return { name: 'llms-txt', postBuild };
+function buildFull(pages) {
+  return pages.map((p) => `# ${p.title}\n\n${p.body}`).join('\n\n---\n\n');
+}
+
+module.exports = function llmsTxtPlugin(context) {
+  // Populated by allContentLoaded, read by both configureWebpack (dev) and
+  // postBuild (static export) — same data, two consumers.
+  let pages = [];
+
+  return {
+    name: 'llms-txt',
+
+    allContentLoaded({allContent}) {
+      pages = buildPages(allContent, context.siteDir);
+    },
+
+    // Serves the same *.md / llms*.txt content during `pnpm start`, so
+    // "Copy Markdown" works in dev too, not just against a static build.
+    configureWebpack() {
+      return {
+        devServer: {
+          setupMiddlewares(middlewares) {
+            middlewares.unshift({
+              name: 'llms-txt-dev',
+              middleware(req, res, next) {
+                const url = req.url.split('?')[0];
+                if (url === '/llms.txt') {
+                  res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+                  res.end(buildIndex(pages, context.siteConfig));
+                  return;
+                }
+                if (url === '/llms-full.txt') {
+                  res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+                  res.end(buildFull(pages));
+                  return;
+                }
+                if (url.endsWith('.md')) {
+                  const route = url === '/index.md' ? '/' : url.replace(/\.md$/, '');
+                  const page = pages.find((p) => p.route === route);
+                  if (page) {
+                    res.setHeader('Content-Type', 'text/markdown; charset=utf-8');
+                    res.end(page.body + footer(context.siteConfig.url));
+                    return;
+                  }
+                }
+                next();
+              },
+            });
+            return middlewares;
+          },
+        },
+      };
+    },
+
+    // Fumadocs-style: llms.txt (index), llms-full.txt (everything), and a
+    // raw *.md copy of every page for agents that fetch `<url>.md` directly.
+    async postBuild({outDir, siteConfig}) {
+      for (const page of pages) {
+        const dest = path.join(outDir, mdPath(page.route));
+        fs.mkdirSync(path.dirname(dest), {recursive: true});
+        fs.writeFileSync(dest, page.body + footer(siteConfig.url));
+      }
+      fs.writeFileSync(path.join(outDir, 'llms.txt'), buildIndex(pages, siteConfig));
+      fs.writeFileSync(path.join(outDir, 'llms-full.txt'), buildFull(pages));
+    },
+  };
 };

--- a/src/theme/DocItem/Content/index.tsx
+++ b/src/theme/DocItem/Content/index.tsx
@@ -1,0 +1,43 @@
+import React, {type ReactNode} from 'react';
+import clsx from 'clsx';
+import {ThemeClassNames} from '@docusaurus/theme-common';
+import {useDoc} from '@docusaurus/plugin-content-docs/client';
+import Heading from '@theme/Heading';
+import MDXContent from '@theme/MDXContent';
+import PageActions from '@site/src/components/PageActions';
+import type {Props} from '@theme/DocItem/Content';
+
+/**
+ Title can be declared inside md content or declared through
+ front matter and added manually. To make both cases consistent,
+ the added title is added under the same div.markdown block
+ See https://github.com/facebook/docusaurus/pull/4882#issuecomment-853021120
+
+ We render a "synthetic title" if:
+ - user doesn't ask to hide it with front matter
+ - the markdown content does not already contain a top-level h1 heading
+*/
+function useSyntheticTitle(): string | null {
+  const {metadata, frontMatter, contentTitle} = useDoc();
+  const shouldRender =
+    !frontMatter.hide_title && typeof contentTitle === 'undefined';
+  if (!shouldRender) {
+    return null;
+  }
+  return metadata.title;
+}
+
+export default function DocItemContent({children}: Props): ReactNode {
+  const syntheticTitle = useSyntheticTitle();
+  return (
+    <div className={clsx(ThemeClassNames.docs.docMarkdown, 'markdown')}>
+      {syntheticTitle && (
+        <header>
+          <Heading as="h1">{syntheticTitle}</Heading>
+        </header>
+      )}
+      <PageActions />
+      <MDXContent>{children}</MDXContent>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- postBuild plugin generates llms.txt, llms-full.txt, and a raw *.md copy of every doc page (routes/titles read from the content-docs plugin's loaded data, so they match Docusaurus's real permalinks even when frontmatter `id`/`slug` overrides the file path)
- same content is also served live under `pnpm start` via a dev-server middleware, so behavior matches production
- each generated `.md` page ends with links to `llms.txt`/`llms-full.txt` so an agent landing on one page can discover the rest of the site
- "Open" toolbar on every doc page (GitHub / ChatGPT / Claude), ejected into src/theme/DocItem/Content so it sits under the title
- added a changeset (minor)

## Test plan
- [x] `pnpm build` — verified `.md` files land at correct permalinks, `llms.txt`/`llms-full.txt` include all 70 docs, footer present
- [x] `pnpm start` — verified `.md`/`llms.txt` routes return real markdown, not the dev-server's HTML fallback
- [x] dev server — toolbar renders, dropdown opens, GitHub/ChatGPT/Claude links point at the markdown URL